### PR TITLE
Fix launch of the container with extra modules, and support of database backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,40 @@ http://localhost/admin.php/config
 
 * http://docs.3liz.com/fr/ 
 
+Upgrading from Lizmap 3.5
+-------------------------
+
+If you want to reuse a database containing tables of Lizmap 3.5, create a directory somewhere,
+for example `./lizmap-previous-config`, and copy these files into it:
+
+- at least the `installer.ini.php` of the Lizmap 3.5 installation (stored originally into `lizmap/var/config`)
+- the `lizmapConfig.ini.php` file if you want to retrieve the list of projects
+- the `profiles.ini.php` file if there are specific connection profiles
+- the `localconfig.ini.php` and `liveconfig.ini.php` if you want to retrieve some specific configuration, but
+  you should remove from them any reference to modules that are not used anymore into your new lizmap container. 
+- if you are using a sqlite database, the `jauth.db` database file (stored originally into `lizmap/var/db`)
+
+Modify the `docker-compose.yml` file to mount the `./lizmap-previous-config` directory at `/var/www/lizmap/previous-config`
+for the lizmap image. For example:
+
+```
+services:
+  lizmap:
+    ...
+    volumes:
+     - ./projects:/io/data:ro
+     - var:/var/www/lizmap/var
+     - ./lizmap-previous-config/:/var/www/lizmap/previous-config
+```
+
+Launch docker compose. It will install the `installer.ini.php` and the `jauth.db`, and other configuration files if
+there are present, and then it will launch the Lizmap installer which will migrate data if needed.
+
+Stop the containers and remove the mount on `/var/www/lizmap/previous-config`, else it will overwrite new data
+at the next start, with the old database and old configuration files.
+
+
+
 -------------------------------
 
 Lizmap Web Application generates dynamically a web map application (php/html/css/js) with the help of Qgis Server ( QGIS Server Tutorial ). You can configure one web map per Qgis project with the QGIS LizMap Plugin.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ___________________________________________________________________________
 
 Building image:
 ---------------
-docker build --build-arg lizmap_version=3.3.13 --build-arg WITH_LDAP=true -t=opengisch/lizmap:3.3.13 .
+docker build --build-arg lizmap_version=3.6.7 -t=opengisch/lizmap:3.6.7 .
 
 Using image:
 ---------------
@@ -28,7 +28,7 @@ docker-compose up -d
 * Now config lizmap on web :
 
 ```
-http://ip/lizmap/www/admin.php/config
+http://localhost/admin.php/config
 ```
 * change URL WMS: 
 

--- a/conf/docker-entrypoint.sh
+++ b/conf/docker-entrypoint.sh
@@ -2,17 +2,40 @@
 set -e
 #generate config file
 VARCONFIG="/var/www/lizmap/var/config"
+PREVIOUSCONFIG="/var/www/lizmap/previous-config"
 
 echo "LE_on:" $LE_on
 echo "LE_staging:" $LE_staging
 echo "LE_email:" $LE_email
 echo "LE_domain:" $LE_domain
 
-
 if [[ ! -d $VARCONFIG ]]; then
   # the var volume is empty, let's fill it with default configuration files and missing directories
   echo "Creating Config file in /var"
   cp -avr /var/www/lizmap/var_install/*  /var/www/lizmap/var
+fi
+
+if [[ -d $PREVIOUSCONFIG ]]; then
+  # there is a volume containing the installer.ini.php file and the jauth.db file of
+  # a previous version of Lizmap, let's install it.
+  if [[ -f $PREVIOUSCONFIG/installer.ini.php ]]; then
+    cp $PREVIOUSCONFIG/installer.ini.php $VARCONFIG/
+  fi
+  if [[ -f $PREVIOUSCONFIG/localconfig.ini.php ]]; then
+    cp $PREVIOUSCONFIG/localconfig.ini.php $VARCONFIG/
+  fi
+  if [[ -f $PREVIOUSCONFIG/liveconfig.ini.php ]]; then
+    cp $PREVIOUSCONFIG/liveconfig.ini.php $VARCONFIG/
+  fi
+  if [[ -f $PREVIOUSCONFIG/profiles.ini.php ]]; then
+    cp $PREVIOUSCONFIG/profiles.ini.php $VARCONFIG/
+  fi
+  if [[ -f $PREVIOUSCONFIG/lizmapConfig.ini.php ]]; then
+    cp $PREVIOUSCONFIG/lizmapConfig.ini.php $VARCONFIG/
+  fi
+  if [[ -f $PREVIOUSCONFIG/jauth.db ]]; then
+    cp $PREVIOUSCONFIG/jauth.db /var/www/lizmap/var/db/
+  fi
 fi
 
 # Apache gets grumpy about PID files pre-existing
@@ -38,13 +61,15 @@ if [[ $LE_on == 'true' ]]; then
 	fi
 fi
 
-# configure extra modules
+# activate extra modules
 php /var/www/lizmap/install/configurator.php saml
 php /var/www/lizmap/install/configurator.php samladmin
 
 # launch the installer, it will launch modules/lizmap installers if lizmap/var was empty or it will launch module updaters
 # if needed..
 php /var/www/lizmap/install/installer.php
+
+# remove cache and temporary files, to be sure that they will be regenerated with the updated configuration and source files
 /var/www/lizmap/install/clean_vartmp.sh
 #set-rights
 /var/www/lizmap/install/set_rights.sh www-data www-data

--- a/conf/docker-entrypoint.sh
+++ b/conf/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 #generate config file
-VAR="/var/www/lizmap/var/config"
+VARCONFIG="/var/www/lizmap/var/config"
 
 echo "LE_on:" $LE_on
 echo "LE_staging:" $LE_staging
@@ -9,13 +9,11 @@ echo "LE_email:" $LE_email
 echo "LE_domain:" $LE_domain
 
 
-if [[ ! -d $VAR ]]; then
+if [[ ! -d $VARCONFIG ]]; then
+  # the var volume is empty, let's fill it with default configuration files and missing directories
   echo "Creating Config file in /var"
   cp -avr /var/www/lizmap/var_install/*  /var/www/lizmap/var
 fi
-
-#set-rights
-/var/www/lizmap/install/set_rights.sh www-data www-data
 
 # Apache gets grumpy about PID files pre-existing
 rm -f /run/apache2/apache2.pid
@@ -39,9 +37,17 @@ if [[ $LE_on == 'true' ]]; then
 		sleep 5
 	fi
 fi
-if [[ $WITH_LDAP == 'true' ]]; then
-  rm -rf /var/www/temp/lizmap/*
-  php /var/www/lizmap/install/installer.php
-fi
+
+# configure extra modules
+php /var/www/lizmap/install/configurator.php saml
+php /var/www/lizmap/install/configurator.php samladmin
+
+# launch the installer, it will launch modules/lizmap installers if lizmap/var was empty or it will launch module updaters
+# if needed..
+php /var/www/lizmap/install/installer.php
+/var/www/lizmap/install/clean_vartmp.sh
+#set-rights
+/var/www/lizmap/install/set_rights.sh www-data www-data
+
 cron
 exec /usr/sbin/apachectl -DFOREGROUND

--- a/conf/docker-entrypoint.sh
+++ b/conf/docker-entrypoint.sh
@@ -61,15 +61,20 @@ if [[ $LE_on == 'true' ]]; then
 	fi
 fi
 
+# launch the configurator. In case this is an upgrade of Lizmap, it will
+# launch the migration of configuration file if needed
+php /var/www/lizmap/install/configurator.php
+
 # activate extra modules
 php /var/www/lizmap/install/configurator.php saml
 php /var/www/lizmap/install/configurator.php samladmin
 
-# launch the installer, it will launch modules/lizmap installers if lizmap/var was empty or it will launch module updaters
-# if needed..
+# launch the installer, it will launch modules/lizmap installers if
+# lizmap/var was empty or it will launch module updaters if needed..
 php /var/www/lizmap/install/installer.php
 
-# remove cache and temporary files, to be sure that they will be regenerated with the updated configuration and source files
+# remove cache and temporary files, to be sure that they will be regenerated
+# with the updated configuration and source files
 /var/www/lizmap/install/clean_vartmp.sh
 #set-rights
 /var/www/lizmap/install/set_rights.sh www-data www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         LE_on: 'false'
         LE_domain: 'example.com'
         LE_email: 'info@example.com'
-        LE_staging: 'true' # change to 'false' when ready for productionb
+        LE_staging: 'true' # change to 'false' when ready for production
     restart: on-failure
     ports:
       - 80:80
@@ -16,6 +16,7 @@ services:
     volumes:
       - ./projects:/io/data:ro
       - var:/var/www/lizmap/var
+      #- ./lizmap-previous-config/:/var/www/lizmap/previous-config
     depends_on:
       - postgis
       - qgisserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        lizmap_version: 3.5.3
+        lizmap_version: 3.6.7
         LE_on: 'false'
         LE_domain: 'example.com'
         LE_email: 'info@example.com'


### PR DESCRIPTION
The lizmap installer and the configuration of extra modules
should be launch at startup, not during the build, else we may loose data
and configuration parameters set by the module installers.
   
Configurators and installers are idempotent, so we can launch them at each starts without issues.

The image now supports also  a temporary volume mount, containing the jauth.db and installers.ini.php file from a previous installation, in order to install it on a new installation.